### PR TITLE
Add TMUX_OVERRIDE_TERM setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ when you login via SSH and will show motd in the first window.
 Autostart can be disabled (or enabled on local host) by setting the variable `TMUX_AUTOSTART=false`, and  
 motd display can be disabled by setting `TMUX_MOTD=false`
 
+You can preserve your default `TERM` value by setting the variable `TMUX_OVERRIDE_TERM=false`. It can
+be useful to get truecolors working properly in neovim.
+
 ### Example
 
 ```sh

--- a/tmux.plugin.zsh
+++ b/tmux.plugin.zsh
@@ -23,10 +23,16 @@ if [[ $PMSPEC != *b* ]] {
 
 if (( $+commands[tmux] )); then
   TMUX_AUTOSTART=${TMUX_AUTOSTART:-'true'}
+  TMUX_OVERRIDE_TERM=${TMUX_OVERRIDE_TERM:-'true'}
 
   if [[ "$TMUX_AUTOSTART" == 'true' && -z "$TMUX" ]]; then
     function _tmux_autostart() {
-      TERM=xterm-256color tmux -2 new-session -A -s main
+      if [[ "$TMUX_OVERRIDE_TERM" == 'true' ]]; then
+        TERM=xterm-256color tmux -2 new-session -A -s main
+      else
+        tmux -2 new-session -A -s main
+      fi
+
       exit 0
     }
 


### PR DESCRIPTION
I had some issue having truecolor in neovim working (kitty terminal).
It would be now possible to disable the redefinition of TERM env variable.

Ask if you need any changes.